### PR TITLE
refactor: enhance NoSQLPage return to include entity count

### DIFF
--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/extensions/sql/tck/TransactionExtension.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/src/test/java/org/eclipse/jnosql/extensions/sql/tck/TransactionExtension.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 public class TransactionExtension implements BeforeEachCallback, AfterEachCallback {
 
     @Override
-    public void beforeEach(ExtensionContext context) throws Exception {
+    public void beforeEach(ExtensionContext context) {
         getEntityManager().getTransaction().begin();
     }
 
@@ -32,7 +32,7 @@ public class TransactionExtension implements BeforeEachCallback, AfterEachCallba
     }
 
     @Override
-    public void afterEach(ExtensionContext context) throws Exception {
+    public void afterEach(ExtensionContext context) {
         getEntityManager().getTransaction().commit();
     }
 

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/DefaultSqlTemplate.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/DefaultSqlTemplate.java
@@ -229,9 +229,7 @@ class DefaultSqlTemplate implements SqlTemplate {
     @Override
     public <T> T insert(T entity) {
         Objects.requireNonNull(entity, "entity is null");
-        return executeInTransaction(() -> {
-            return insertExecution(entity);
-        });
+        return executeInTransaction(() -> insertExecution(entity));
     }
 
     @Override

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlRepositoryProducer.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/SqlRepositoryProducer.java
@@ -32,10 +32,8 @@ import java.util.Objects;
  * A class responsible for producing and managing SQL-based repository implementations.
  * This class uses a combination of infrastructure providers and repository operation
  * providers to dynamically generate implementations for repository interfaces.
- *
  * The generated repositories utilize SQL templates and metadata to map the operations
  * performed via the repository interface into SQL queries and commands.
- *
  * The class is scoped as {@code @ApplicationScoped}, ensuring that only one instance is
  * created within the application context.
  */

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/spi/AbstractRepositoryPersistenceBean.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/spi/AbstractRepositoryPersistenceBean.java
@@ -73,12 +73,17 @@ public abstract class AbstractRepositoryPersistenceBean<T> extends AbstractBean<
     }
 
     /**
-     * Invocation handler for invoking repository methods
+     * Creates an {@link InvocationHandler} that facilitates the interaction between
+     * the repository interface and the persistence layer.
      *
-     * @param entitiesMetadata
-     * @param template         Template for executing queries
-     * @param converters
-     * @return
+     * @param entitiesMetadata Metadata about the entities being managed, which contains
+     *                         details about entity relationships, mappings, and constraints.
+     * @param template         The persistence document template used to execute
+     *                         persistence operations, such as storing or retrieving data.
+     * @param converters       The utility that handles conversions between entity objects
+     *                         and their database representations, ensuring compatibility
+     *                         between application and persistence formats.
+     * @return An {@link InvocationHandler} responsible for delegating repository method invocations to the persistence layer.
      */
     abstract protected InvocationHandler createInvocationHandler(EntitiesMetadata entitiesMetadata, PersistenceDocumentTemplate template, Converters converters);
 

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/spi/CustomRepositoryPersistenceBean.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/spi/CustomRepositoryPersistenceBean.java
@@ -38,9 +38,14 @@ import java.lang.reflect.InvocationHandler;
  */
 public class CustomRepositoryPersistenceBean<T> extends AbstractRepositoryPersistenceBean<T> {
 
+
     /**
-     * @param type the bean class
-     * @param beanManager
+     * Constructs an instance of {@code CustomRepositoryPersistenceBean}. This constructor is
+     * used to initialize and manage custom repository beans within the Jakarta Persistence
+     * context, extending the capabilities of the {@code AbstractRepositoryPersistenceBean}.
+     *
+     * @param type the class of the custom repository to be managed.
+     * @param beanManager the {@code BeanManager} instance responsible for handling the CDI context.
      */
     public CustomRepositoryPersistenceBean(Class<?> type, BeanManager beanManager) {
         super(type, beanManager);

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/spi/RepositoryPersistenceBean.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/extensions/sql/repository/spi/RepositoryPersistenceBean.java
@@ -40,11 +40,15 @@ import java.lang.reflect.InvocationHandler;
  */
 public class RepositoryPersistenceBean<T extends DataRepository<T, ?>> extends AbstractRepositoryPersistenceBean<T> {
 
+
     /**
-     * Constructor
+     * Constructs an instance of {@code RepositoryPersistenceBean}. This constructor
+     * is used to initialize and manage repository beans within the Jakarta
+     * Persistence context, extending the capabilities of the
+     * {@code AbstractRepositoryPersistenceBean}.
      *
-     * @param type The bean class
-     * @param beanManager
+     * @param type the class of the repository to be managed.
+     * @param beanManager the {@code BeanManager} instance responsible for handling the CDI context.
      */
     public RepositoryPersistenceBean(Class<?> type, BeanManager beanManager) {
         super(type, beanManager);

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/CdiUtil.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/CdiUtil.java
@@ -43,9 +43,13 @@ public class CdiUtil {
     }
 
     /**
-     * Find all qualifiers in the list of annotations, including qualifiers nested in stereotypes
-     * @param annotations
-     * @return
+     * Retrieves all qualifiers from the given annotations, including those nested within stereotypes.
+     * This method resolves qualifiers recursively by processing stereotypes to find any associated
+     * qualifiers, avoiding duplicate processing of already visited stereotypes.
+     *
+     * @param beanManager the CDI bean manager used to determine whether an annotation is a qualifier or stereotype
+     * @param annotations the initial set of annotations to retrieve qualifiers from
+     * @return a set of qualifiers extracted from the provided annotations and any nested stereotypes
      */
     public static Set<Annotation> getAllQualifiersRecursively(BeanManager beanManager, Annotation... annotations) {
         Set<Annotation> qualifiers = new HashSet<>();

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/CdiUtil.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/CdiUtil.java
@@ -85,10 +85,15 @@ public class CdiUtil {
         }
     }
 
+
     /**
-     * Find all interceptor bindings in the list of annotations, including interceptor bindings nested in stereotypes
-     * @param annotations
-     * @return
+     * Retrieves all interceptor bindings from the given annotations, including those nested within stereotypes.
+     * This method resolves interceptor bindings recursively by processing stereotypes to find any associated
+     * interceptor bindings, avoiding duplicate processing of already visited stereotypes.
+     *
+     * @param beanManager the CDI bean manager used to determine whether an annotation is an interceptor binding or stereotype
+     * @param annotations the initial set of annotations to retrieve interceptor bindings from
+     * @return a set of interceptor bindings extracted from the provided annotations and any nested stereotypes
      */
     public static Set<Annotation> getAllInterceptorBindingsRecursively(BeanManager beanManager, Annotation... annotations) {
         Set<Annotation> interceptorBindings = new HashSet<>();

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceDatabaseManagerProvider.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/communication/PersistenceDatabaseManagerProvider.java
@@ -48,9 +48,7 @@ public class PersistenceDatabaseManagerProvider {
 
     private Map<String, EntityType<?>> collectEntityTypesByName(EntityManagerFactory entityManagerFactory) {
         Map<String, EntityType<?>> entityTypesByName = new ConcurrentHashMap<>();
-        entityManagerFactory.getMetamodel().getEntities().forEach(type -> {
-            entityTypesByName.put(type.getName(), type);
-        });
+        entityManagerFactory.getMetamodel().getEntities().forEach(type -> entityTypesByName.put(type.getName(), type));
         return entityTypesByName;
     }
 

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/BaseQueryParser.java
@@ -243,6 +243,7 @@ abstract class BaseQueryParser {
         }
     }
 
+    @SafeVarargs
     static void requireComparisonSupportsIgnoreCase(CriteriaCondition criteria, Expression<? extends Comparable>... operands) {
             if (!Stream.of(operands).allMatch(BaseQueryParser::isStringExpression)) {
                 throw new UnsupportedOperationException("IgnoreCase supported only for String values. Criteria: " + criteria);

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/DeleteQueryParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/DeleteQueryParser.java
@@ -63,9 +63,7 @@ class DeleteQueryParser extends BaseUpdateQueryParser {
             return deleteAll(type);
         } else {
             final CriteriaCondition criteria = deleteQuery.condition().get();
-            Query query = buildDeleteQuery(type, ctx -> {
-                return ctx.query().where(parseCriteria(criteria, ctx.queryContext()));
-            });
+            Query query = buildDeleteQuery(type, ctx -> ctx.query().where(parseCriteria(criteria, ctx.queryContext())));
             return query.executeUpdate();
         }
     }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/QueryModifier.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/QueryModifier.java
@@ -90,6 +90,7 @@ interface QueryModifier<FROM, RESULT> extends Function<SelectQueryParser.SelectQ
         };
     }
 
+    @SafeVarargs
     static <FROM, RESULT> QueryModifier<FROM, RESULT> combine(QueryModifier<FROM, RESULT>... modifiers) {
         return ctx -> {
             CriteriaQuery<RESULT> query = ctx.query();

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/parser/OptionalPartsParser.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/parser/OptionalPartsParser.java
@@ -71,7 +71,7 @@ public class OptionalPartsParser {
         if (startsWith(FROM)) {
             fromClause();
         } else {
-            updatedQueryString.append(FROM + " " + entity);
+            updatedQueryString.append(FROM + " ").append(entity);
         }
         skipSpace();
         // do not care about the rest

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceDynamicReturnConverter.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/repository/JakartaPersistenceDynamicReturnConverter.java
@@ -100,9 +100,7 @@ public enum JakartaPersistenceDynamicReturnConverter {
                 .pagination(pageRequest)
                 .streamPagination(p -> prepare.result())
                 .singleResultPagination(p -> prepare.singleResult())
-                .page((p, l) -> {
-                    return prepare.selectOffset(pageRequest);
-                }).build();
+                .page((p, l) -> prepare.selectOffset(pageRequest)).build();
 
         return convert(dynamicReturn);
     }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/spi/MethodInterceptor.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/main/java/org/eclipse/jnosql/jakartapersistence/mapping/spi/MethodInterceptor.java
@@ -66,12 +66,17 @@ public interface MethodInterceptor {
         }
     }
 
+
     /**
-     * Called to intercept any methods.
+     * Intercepts and processes a method invocation represented by the given {@link InvocationContext}.
+     * This method allows implementing custom logic before or after the invocation proceeds
+     * or can alter the behavior of the method invocation entirely.
      *
-     * @param context Invocation context
-     * @return value returned by the context invocation
-     * @throws Exception
+     * @param context the invocation context representing details about the target method call,
+     *                including the target object, method, parameters, and more.
+     * @return the result of the intercepted invocation, which could either be the outcome of
+     *         the original method execution or a custom value provided by the interceptor.
+     * @throws Exception if an error occurs during the interception or method execution process.
      */
     Object intercept(InvocationContext context) throws Exception;
 

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/QualifierTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/ee/omnifish/jnosql/jakartapersistence/QualifierTest.java
@@ -51,8 +51,6 @@ public class QualifierTest {
 
     @Test
     void repositoryCannotBeInjectedWithoutQualifier() {
-        assertThrows(Exception.class, () -> {
-            CDI.current().select(QualifiedPersonRepository.class).get();
-        });
+        assertThrows(Exception.class, () -> CDI.current().select(QualifiedPersonRepository.class).get());
     }
 }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/DeleteQueryConverterTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/DeleteQueryConverterTest.java
@@ -84,9 +84,7 @@ class DeleteQueryConverterTest {
             var remaining = template.select(SelectQuery.select().from("Computer").build()).toList();
 
             // then
-            SoftAssertions.assertSoftly(soft -> {
-                soft.assertThat(remaining).isEmpty();
-            });
+            SoftAssertions.assertSoftly(soft -> soft.assertThat(remaining).isEmpty());
         }
     }
 
@@ -114,11 +112,9 @@ class DeleteQueryConverterTest {
             var remaining = template.<Computer>select(SelectQuery.select().from("Computer").build()).toList();
 
             // then
-            SoftAssertions.assertSoftly(soft -> {
-                soft.assertThat(remaining)
-                        .extracting(Computer::getRelease)
-                        .containsExactly(2023L);
-            });
+            SoftAssertions.assertSoftly(soft -> soft.assertThat(remaining)
+                    .extracting(Computer::getRelease)
+                    .containsExactly(2023L));
         }
 
         @Test
@@ -142,11 +138,9 @@ class DeleteQueryConverterTest {
             var remaining = template.<Computer>select(SelectQuery.select().from("Computer").build()).toList();
 
             // then
-            SoftAssertions.assertSoftly(soft -> {
-                soft.assertThat(remaining)
-                        .extracting(Computer::getRelease)
-                        .containsExactly(2022L);
-            });
+            SoftAssertions.assertSoftly(soft -> soft.assertThat(remaining)
+                    .extracting(Computer::getRelease)
+                    .containsExactly(2022L));
         }
 
         @Test
@@ -170,11 +164,9 @@ class DeleteQueryConverterTest {
             var remaining = template.<Computer>select(SelectQuery.select().from("Computer").build()).toList();
 
             // then
-            SoftAssertions.assertSoftly(soft -> {
-                soft.assertThat(remaining)
-                        .extracting(Computer::getRelease)
-                        .containsExactly(2022L);
-            });
+            SoftAssertions.assertSoftly(soft -> soft.assertThat(remaining)
+                    .extracting(Computer::getRelease)
+                    .containsExactly(2022L));
         }
 
         @Test
@@ -198,11 +190,9 @@ class DeleteQueryConverterTest {
             var remaining = template.<Computer>select(SelectQuery.select().from("Computer").build()).toList();
 
             // then
-            SoftAssertions.assertSoftly(soft -> {
-                soft.assertThat(remaining)
-                        .extracting(Computer::getModel)
-                        .containsExactlyInAnyOrder("ThinkPad", "XPS");
-            });
+            SoftAssertions.assertSoftly(soft -> soft.assertThat(remaining)
+                    .extracting(Computer::getModel)
+                    .containsExactlyInAnyOrder("ThinkPad", "XPS"));
         }
     }
 
@@ -235,14 +225,12 @@ class DeleteQueryConverterTest {
             ).toList();
 
             // then
-            SoftAssertions.assertSoftly(soft -> {
-                soft.assertThat(remaining)
-                        .extracting(Computer::getModel, Computer::getRelease)
-                        .containsExactlyInAnyOrder(
-                                tuple("MacBook", 2024L),
-                                tuple("ThinkPad", 2023L)
-                        );
-            });
+            SoftAssertions.assertSoftly(soft -> soft.assertThat(remaining)
+                    .extracting(Computer::getModel, Computer::getRelease)
+                    .containsExactlyInAnyOrder(
+                            tuple("MacBook", 2024L),
+                            tuple("ThinkPad", 2023L)
+                    ));
         }
 
         @Test
@@ -270,11 +258,9 @@ class DeleteQueryConverterTest {
             ).toList();
 
             // then
-            SoftAssertions.assertSoftly(soft -> {
-                soft.assertThat(remaining)
-                        .extracting(Computer::getModel)
-                        .containsExactly("XPS");
-            });
+            SoftAssertions.assertSoftly(soft -> soft.assertThat(remaining)
+                    .extracting(Computer::getModel)
+                    .containsExactly("XPS"));
         }
 
         @Test
@@ -301,11 +287,9 @@ class DeleteQueryConverterTest {
             ).toList();
 
             // then
-            SoftAssertions.assertSoftly(soft -> {
-                soft.assertThat(remaining)
-                        .extracting(Computer::getRelease)
-                        .containsExactly(2024L);
-            });
+            SoftAssertions.assertSoftly(soft -> soft.assertThat(remaining)
+                    .extracting(Computer::getRelease)
+                    .containsExactly(2024L));
         }
     }
 

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/UpdateQueryConverterTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/UpdateQueryConverterTest.java
@@ -92,11 +92,9 @@ class UpdateQueryConverterTest {
             var result = template.<Computer>select(SelectQuery.select().from("Computer").build()).toList();
 
             // then
-            SoftAssertions.assertSoftly(soft -> {
-                soft.assertThat(result)
-                        .extracting(Computer::getModel)
-                        .containsExactlyInAnyOrder("Updated", "Updated");
-            });
+            SoftAssertions.assertSoftly(soft -> soft.assertThat(result)
+                    .extracting(Computer::getModel)
+                    .containsExactlyInAnyOrder("Updated", "Updated"));
         }
     }
 
@@ -124,14 +122,12 @@ class UpdateQueryConverterTest {
             var result = template.<Computer>select(SelectQuery.select().from("Computer").build()).toList();
 
             // then
-            SoftAssertions.assertSoftly(soft -> {
-                soft.assertThat(result)
-                        .extracting(Computer::getModel, Computer::getRelease)
-                        .containsExactlyInAnyOrder(
-                                tuple("Updated", 2024L),
-                                tuple("ThinkPad", 2023L)
-                        );
-            });
+            SoftAssertions.assertSoftly(soft -> soft.assertThat(result)
+                    .extracting(Computer::getModel, Computer::getRelease)
+                    .containsExactlyInAnyOrder(
+                            tuple("Updated", 2024L),
+                            tuple("ThinkPad", 2023L)
+                    ));
         }
 
         @Test
@@ -155,15 +151,13 @@ class UpdateQueryConverterTest {
             var result = template.<Computer>select(SelectQuery.select().from("Computer").build()).toList();
 
             // then
-            SoftAssertions.assertSoftly(soft -> {
-                soft.assertThat(result)
-                        .extracting(Computer::getModel, Computer::getRelease)
-                        .containsExactlyInAnyOrder(
-                                tuple("Modern", 2024L),
-                                tuple("Modern", 2023L),
-                                tuple("XPS", 2022L)
-                        );
-            });
+            SoftAssertions.assertSoftly(soft -> soft.assertThat(result)
+                    .extracting(Computer::getModel, Computer::getRelease)
+                    .containsExactlyInAnyOrder(
+                            tuple("Modern", 2024L),
+                            tuple("Modern", 2023L),
+                            tuple("XPS", 2022L)
+                    ));
         }
 
         @Test
@@ -187,15 +181,13 @@ class UpdateQueryConverterTest {
             var result = template.<Computer>select(SelectQuery.select().from("Computer").build()).toList();
 
             // then
-            SoftAssertions.assertSoftly(soft -> {
-                soft.assertThat(result)
-                        .extracting(Computer::getModel, Computer::getRelease)
-                        .containsExactlyInAnyOrder(
-                                tuple("Recent", 2024L),
-                                tuple("Recent", 2023L),
-                                tuple("XPS", 2022L)
-                        );
-            });
+            SoftAssertions.assertSoftly(soft -> soft.assertThat(result)
+                    .extracting(Computer::getModel, Computer::getRelease)
+                    .containsExactlyInAnyOrder(
+                            tuple("Recent", 2024L),
+                            tuple("Recent", 2023L),
+                            tuple("XPS", 2022L)
+                    ));
         }
     }
 

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/CountByOperationRepositoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/CountByOperationRepositoryTest.java
@@ -85,9 +85,7 @@ class CountByOperationRepositoryTest extends AbstractTestRepository {
             long count = repository.countByRelease(2023);
 
             // then
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(count).isEqualTo(2);
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(count).isEqualTo(2));
 
             // cleanup
             repository.deleteById(c1.getId());
@@ -106,9 +104,7 @@ class CountByOperationRepositoryTest extends AbstractTestRepository {
             long count = repository.countByModel("NonExisting");
 
             // then
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(count).isZero();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(count).isZero());
 
             // cleanup
             repository.deleteById(c1.getId());

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/DeleteByOperationRepositoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/DeleteByOperationRepositoryTest.java
@@ -128,9 +128,7 @@ import org.junit.jupiter.api.Test;
             int deleted = repository.deleteByRelease(1999);
 
             // then
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(deleted).isZero();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(deleted).isZero());
 
             // cleanup
             repository.deleteById(c1.getId());

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/DeleteOperationRepositoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/DeleteOperationRepositoryTest.java
@@ -62,9 +62,7 @@ import java.util.List;
             // then
             var result = repository.findAll().toList();
 
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result).isEmpty();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(result).isEmpty());
         }
 
         @Test
@@ -81,9 +79,7 @@ import java.util.List;
             // then
             var result = repository.findAll().toList();
 
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result).isEmpty();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(result).isEmpty());
         }
 
         @Test
@@ -100,9 +96,7 @@ import java.util.List;
             // then
             var result = repository.findAll().toList();
 
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result).isEmpty();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(result).isEmpty());
         }
 
         @Test
@@ -120,11 +114,9 @@ import java.util.List;
             // then
             var result = repository.findAll().toList();
 
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result)
-                        .extracting(Computer::getModel)
-                        .containsExactly("ThinkPad");
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(result)
+                    .extracting(Computer::getModel)
+                    .containsExactly("ThinkPad"));
 
             // cleanup
             repository.deleteById(c2.getId());
@@ -140,9 +132,7 @@ import java.util.List;
             // then
             var result = repository.findAll().toList();
 
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result).isEmpty();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(result).isEmpty());
         }
     }
 }

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/FindByOperationRepositoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/FindByOperationRepositoryTest.java
@@ -192,9 +192,7 @@ class FindByOperationRepositoryTest extends AbstractTestRepository {
             var result = repository.findByModel("NonExisting");
 
             // then
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result).isEmpty();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(result).isEmpty());
 
             // cleanup
             repository.deleteById(c1.getId());

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/FindOperationRepositoryTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/FindOperationRepositoryTest.java
@@ -59,9 +59,7 @@ class FindOperationRepositoryTest extends AbstractTestRepository {
             var result = repository.allComputers();
 
             // then
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result).hasSize(2);
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(result).hasSize(2));
 
             // cleanup
             repository.deleteById(c1.getId());
@@ -156,9 +154,7 @@ class FindOperationRepositoryTest extends AbstractTestRepository {
             var result = repository.computersBy("NonExisting");
 
             // then
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result).isEmpty();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(result).isEmpty());
 
             // cleanup
             repository.deleteById(c1.getId());

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/SqlRepositoryAdapterTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/SqlRepositoryAdapterTest.java
@@ -171,9 +171,7 @@ class SqlRepositoryAdapterTest {
             var exists = repository.existsById(computer.getId());
 
             // then
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(exists).isTrue();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(exists).isTrue());
         }
 
         @Test
@@ -184,9 +182,7 @@ class SqlRepositoryAdapterTest {
             var exists = repository.existsById(999L);
 
             // then
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(exists).isFalse();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(exists).isFalse());
         }
 
         @Test
@@ -228,9 +224,7 @@ class SqlRepositoryAdapterTest {
             var result = repository.findByIdIn(List.<Long>of()).toList();
 
             // then
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result).isEmpty();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(result).isEmpty());
         }
 
         @Test
@@ -263,9 +257,7 @@ class SqlRepositoryAdapterTest {
             var exists = repository.existsById(computer.getId());
 
             // then
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(exists).isTrue();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(exists).isTrue());
         }
 
         @Test
@@ -276,9 +268,7 @@ class SqlRepositoryAdapterTest {
             var exists = repository.existsById(999L);
 
             // then
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(exists).isFalse();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(exists).isFalse());
         }
 
         @Test
@@ -351,9 +341,7 @@ class SqlRepositoryAdapterTest {
             var result = repository.findByIdIn(List.<Long>of()).toList();
 
             // then
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result).isEmpty();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(result).isEmpty());
         }
 
         @Test
@@ -390,9 +378,7 @@ class SqlRepositoryAdapterTest {
             var result = repository.findAll().toList();
 
             // then
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result).isEmpty();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(result).isEmpty());
         }
 
         @Test
@@ -437,9 +423,7 @@ class SqlRepositoryAdapterTest {
             // then
             var result = repository.findAll().toList();
 
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result).isEmpty();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(result).isEmpty());
         }
 
         @Test
@@ -455,9 +439,7 @@ class SqlRepositoryAdapterTest {
             // then
             var result = repository.findAll().toList();
 
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result).isEmpty();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(result).isEmpty());
         }
 
         @Test
@@ -482,9 +464,7 @@ class SqlRepositoryAdapterTest {
             // then
             var result = repository.findAll().toList();
 
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result).isEmpty();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(result).isEmpty());
         }
 
         @Test
@@ -512,9 +492,7 @@ class SqlRepositoryAdapterTest {
             // then
             var result = repository.findAll().toList();
 
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result).isEmpty();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(result).isEmpty());
         }
 
         @Test
@@ -628,9 +606,7 @@ class SqlRepositoryAdapterTest {
             var result = repository.updateAll(List.of());
 
             // then
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result).isEmpty();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(result).isEmpty());
         }
     }
 
@@ -712,9 +688,7 @@ class SqlRepositoryAdapterTest {
             var result = repository.insertAll(List.of());
 
             // then
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result).isEmpty();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(result).isEmpty());
         }
     }
 
@@ -834,9 +808,7 @@ class SqlRepositoryAdapterTest {
             var result = repository.saveAll(List.of());
 
             // then
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result).isEmpty();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(result).isEmpty());
         }
 
         @Test

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/SqlRepositoryProducerTest.java
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/src/test/java/org/eclipse/jnosql/extensions/sql/repository/SqlRepositoryProducerTest.java
@@ -67,9 +67,7 @@ class SqlRepositoryProducerTest extends AbstractTestRepository {
             var repository = producer.get(ComputerRepository.class, template);
 
             // then
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(Proxy.isProxyClass(repository.getClass())).isTrue();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(Proxy.isProxyClass(repository.getClass())).isTrue());
         }
 
         @Test
@@ -160,9 +158,7 @@ class SqlRepositoryProducerTest extends AbstractTestRepository {
             // then
             var result = repository.findById(computer.getId());
 
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result).isEmpty();
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(result).isEmpty());
         }
 
         @Test
@@ -177,11 +173,9 @@ class SqlRepositoryProducerTest extends AbstractTestRepository {
             var result = repository.findAll().toList();
 
             // then
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result)
-                        .extracting(Computer::getModel)
-                        .contains("MacBook Pro", "ThinkPad");
-            });
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(result)
+                    .extracting(Computer::getModel)
+                    .contains("MacBook Pro", "ThinkPad"));
 
             // cleanup (important: isolate test)
             repository.deleteById(c1.getId());

--- a/jnosql-lite/mapping-lite-processor/src/main/resources/repository_semi_structure.mustache
+++ b/jnosql-lite/mapping-lite-processor/src/main/resources/repository_semi_structure.mustache
@@ -145,7 +145,7 @@ public class {{className}} implements {{repository}} {
         pageRequest.size(), NoSQLPage.skip(pageRequest), null, metadata.name(), java.util.Collections.emptyList());
 
         List<{{entityType}}> entities = template().<{{entityType}}>select(query).toList();
-        return NoSQLPage.of(entities, pageRequest);
+        return NoSQLPage.of(entities, pageRequest, () -> template.count(query));
     }
 
    @Override


### PR DESCRIPTION
This pull request makes a small but important change to how paginated query results are returned in the repository implementation template. Now, the total count of matching entities is provided using a `count` query, which allows for more accurate pagination information.

- Pagination improvement:
  * [`repository_semi_structure.mustache`](diffhunk://#diff-0de5cc5f91b9b62d08eda15c481c86a1b2fecd87a87f2b808f0240e84d99a817L148-R148): Updated the method returning paginated results to supply a `count` callback, ensuring the total number of matching entities is available for pagination.