### PR TITLE
update project version to 1.1.14 in all pom.xml files 

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,8 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 
 == [Unreleased]
 
+== [1.1.14] - 2026-06-01
+
 == [1.1.12] - 2026-01-05
 
 == [1.1.11] - 2024-11-16

--- a/README.adoc
+++ b/README.adoc
@@ -61,7 +61,7 @@ After removing the reflection engine, include the Java Annotation Processor. The
 <dependency>
     <groupId>org.eclipse.jnosql.lite</groupId>
     <artifactId>mapping-lite-processor</artifactId>
-    <version>1.1.12</version>
+    <version>1.1.14</version>
     <scope>provided</scope>
 </dependency>
 ----
@@ -83,7 +83,7 @@ After removing the reflection engine, include the Java Annotation Processor. The
                     <path>
                     <groupId>org.eclipse.jnosql.lite</groupId>
                     <artifactId>mapping-lite-processor</artifactId>
-                    <version>1.1.12</version>
+                    <version>1.1.14</version>
                     </path>
                     <!-- other annotation processors -->
                 </annotationProcessorPaths>
@@ -125,7 +125,7 @@ To enable the generation of the static metamodel for your entities, include the 
 <dependency>
     <groupId>org.eclipse.jnosql.metamodel</groupId>
     <artifactId>mapping-metamodel-processor</artifactId>
-    <version>1.1.12</version>
+    <version>1.1.14</version>
     <scope>provided</scope>
 </dependency>
 ----
@@ -167,7 +167,7 @@ Eclipse JNoSQL provide support for bean validation. It will validate before inse
 <dependency>
     <groupId>org.eclipse.jnosql.mapping</groupId>
     <artifactId>jnosql-mapping-validation</artifactId>
-    <version>1.1.12</version>
+    <version>1.1.14</version>
 </dependency>
 ----
 
@@ -227,13 +227,13 @@ The Criteria API can be used via CriteriaDocumentTemplate.
   <dependency>
     <groupId>org.eclipse.jnosql.mapping</groupId>
     <artifactId>jnosql-metamodel-processor-extension</artifactId>
-    <version>1.1.12</version>
+    <version>1.1.14</version>
     <optional>true</optional>
   </dependency>
   <dependency>
       <groupId>org.eclipse.jnosql.mapping</groupId>
       <artifactId>jnosql-criteria-extension</artifactId>
-      <version>1.1.12</version>
+      <version>1.1.14</version>
   </dependency>
 ----
 
@@ -246,7 +246,7 @@ Apache Tinkerpop Connections is a project that provides multiple `GraphConfigura
 <dependency>
   <groupId>org.eclipse.jnosql.mapping</groupId>
   <artifactId>jnosql-tinkerpop-connections</artifactId>
-  <version>1.1.12</version>
+  <version>1.1.14</version>
 </dependency>
 ----
 

--- a/jnosql-data-tck-runner/pom.xml
+++ b/jnosql-data-tck-runner/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.eclipse.jnosql.mapping</groupId>
 		<artifactId>jnosql-mapping-extensions</artifactId>
-		<version>1.1.14-SNAPSHOT</version>
+		<version>1.1.14</version>
 	</parent>
 
 	<artifactId>jnosql-data-tck-runner</artifactId>

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/pom.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-jakarta-persistence-parent</artifactId>
-        <version>1.1.14-SNAPSHOT</version>
+        <version>1.1.14</version>
     </parent>
 
     <artifactId>jnosql-jakarta-persistence-data-tck-runner</artifactId>

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/pom.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-jakarta-persistence-parent</artifactId>
-        <version>1.1.14-SNAPSHOT</version>
+        <version>1.1.14</version>
     </parent>
 
     <artifactId>jnosql-jakarta-persistence</artifactId>

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/pom.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-jakarta-persistence-parent</artifactId>
-        <version>1.1.14-SNAPSHOT</version>
+        <version>1.1.14</version>
     </parent>
 
     <artifactId>jnosql-jakarta-persistence-scanner</artifactId>

--- a/jnosql-jakarta-persistence/pom.xml
+++ b/jnosql-jakarta-persistence/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-extensions</artifactId>
-        <version>1.1.14-SNAPSHOT</version>
+        <version>1.1.14</version>
     </parent>
 
     <artifactId>jnosql-jakarta-persistence-parent</artifactId>

--- a/jnosql-lite/mapping-lite-column-test/pom.xml
+++ b/jnosql-lite/mapping-lite-column-test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.lite</groupId>
         <artifactId>jnosql-lite-parent</artifactId>
-        <version>1.1.14-SNAPSHOT</version>
+        <version>1.1.14</version>
     </parent>
 
     <artifactId>mapping-lite-column-test</artifactId>

--- a/jnosql-lite/mapping-lite-core-test/pom.xml
+++ b/jnosql-lite/mapping-lite-core-test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.lite</groupId>
         <artifactId>jnosql-lite-parent</artifactId>
-        <version>1.1.14-SNAPSHOT</version>
+        <version>1.1.14</version>
     </parent>
 
     <artifactId>mapping-lite-core-test</artifactId>

--- a/jnosql-lite/mapping-lite-document-test/pom.xml
+++ b/jnosql-lite/mapping-lite-document-test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.lite</groupId>
         <artifactId>jnosql-lite-parent</artifactId>
-        <version>1.1.14-SNAPSHOT</version>
+        <version>1.1.14</version>
     </parent>
 
     <artifactId>mapping-lite-document-test</artifactId>

--- a/jnosql-lite/mapping-lite-graph-test/pom.xml
+++ b/jnosql-lite/mapping-lite-graph-test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.lite</groupId>
         <artifactId>jnosql-lite-parent</artifactId>
-        <version>1.1.14-SNAPSHOT</version>
+        <version>1.1.14</version>
     </parent>
 
     <artifactId>mapping-lite-graph-test</artifactId>

--- a/jnosql-lite/mapping-lite-key-value-test/pom.xml
+++ b/jnosql-lite/mapping-lite-key-value-test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.lite</groupId>
         <artifactId>jnosql-lite-parent</artifactId>
-        <version>1.1.14-SNAPSHOT</version>
+        <version>1.1.14</version>
     </parent>
 
     <artifactId>mapping-lite-key-value-test</artifactId>

--- a/jnosql-lite/mapping-lite-processor/pom.xml
+++ b/jnosql-lite/mapping-lite-processor/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.lite</groupId>
         <artifactId>jnosql-lite-parent</artifactId>
-        <version>1.1.14-SNAPSHOT</version>
+        <version>1.1.14</version>
     </parent>
 
     <artifactId>mapping-lite-processor</artifactId>

--- a/jnosql-lite/pom.xml
+++ b/jnosql-lite/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-extensions</artifactId>
-        <version>1.1.14-SNAPSHOT</version>
+        <version>1.1.14</version>
     </parent>
 
     <groupId>org.eclipse.jnosql.lite</groupId>

--- a/jnosql-mapping-validation/pom.xml
+++ b/jnosql-mapping-validation/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-extensions</artifactId>
-        <version>1.1.14-SNAPSHOT</version>
+        <version>1.1.14</version>
     </parent>
 
     <artifactId>jnosql-mapping-validation</artifactId>

--- a/jnosql-nosql-tck-runner/pom.xml
+++ b/jnosql-nosql-tck-runner/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-extensions</artifactId>
-        <version>1.1.14-SNAPSHOT</version>
+        <version>1.1.14</version>
     </parent>
 
     <artifactId>jnosql-nosql-tck-runner</artifactId>

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/pom.xml
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.metamodel</groupId>
         <artifactId>jnosql-static-metamodel-parent</artifactId>
-        <version>1.1.14-SNAPSHOT</version>
+        <version>1.1.14</version>
     </parent>
 
     <artifactId>mapping-metamodel-processor</artifactId>

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/pom.xml
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.metamodel</groupId>
         <artifactId>jnosql-static-metamodel-parent</artifactId>
-        <version>1.1.14-SNAPSHOT</version>
+        <version>1.1.14</version>
     </parent>
 
     <artifactId>mapping-lite-sample</artifactId>

--- a/jnosql-static-metamodel/pom.xml
+++ b/jnosql-static-metamodel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-extensions</artifactId>
-        <version>1.1.14-SNAPSHOT</version>
+        <version>1.1.14</version>
     </parent>
 
     <groupId>org.eclipse.jnosql.metamodel</groupId>

--- a/jnosql-tinkerpop-connections/pom.xml
+++ b/jnosql-tinkerpop-connections/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-extensions</artifactId>
-        <version>1.1.14-SNAPSHOT</version>
+        <version>1.1.14</version>
     </parent>
 
     <artifactId>jnosql-tinkerpop-connections</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-parent</artifactId>
-        <version>1.1.14-SNAPSHOT</version>
+        <version>1.1.14</version>
     </parent>
 
     <artifactId>jnosql-mapping-extensions</artifactId>


### PR DESCRIPTION
This pull request updates the project version from `1.1.14-SNAPSHOT` and `1.1.12` to the stable release `1.1.14` across all relevant modules, documentation, and dependency references. This ensures consistency in versioning for the new release and updates the documentation to reflect the latest version.

Version updates for release:

* Updated the project version from `1.1.14-SNAPSHOT` to `1.1.14` in all `pom.xml` files for modules including `jnosql-data-tck-runner`, `jnosql-jakarta-persistence` (and submodules), `jnosql-lite` (and submodules), `jnosql-mapping-validation`, `jnosql-nosql-tck-runner`, `jnosql-static-metamodel` (and submodules), and `jnosql-tinkerpop-connections`. [[1]](diffhunk://#diff-72be70ac94b01a22f0192470d335d9e18459664ce70f5c9d370cc979b8a76612L27-R27) [[2]](diffhunk://#diff-a036342e5c2755aa0fd2562a028161db5690d3a7517f37cbfb60b3a74aafdd77L24-R24) [[3]](diffhunk://#diff-967574e47a06a93754dbf3ca9f98cd6f3cfe419d3c6e1b9c7e07fb11461edf7cL26-R26) [[4]](diffhunk://#diff-879d49e35a76bf05eff31d8a8105370dd2c0f2e79596af4a769b6270711d7eaaL25-R25) [[5]](diffhunk://#diff-6f76e51fd608138a8daf600ce3d7d8d31a88ff9eb8ab019686684fafbac16769L23-R23) [[6]](diffhunk://#diff-d953d50d7994a9b3dd4ed263bcd62d804a4f500c217a6e4705710644135a7676L23-R23) [[7]](diffhunk://#diff-61fd6e3e1e141afc731389613c008e2fb4a68dc2e7fa97b71df98ce5494247c4L23-R23) [[8]](diffhunk://#diff-5d08708365a4193579002184096342d1e32c6df2073fb4f3d32fa39516a64a13L23-R23) [[9]](diffhunk://#diff-6fb917976a291cbd3864a0b2554846df33ea823366e9f699d2b19243584f8cf1L23-R23) [[10]](diffhunk://#diff-87356e55d6123057951b48f72f8eb581910bff3555ae5c8bf83cd1152b39032eL23-R23) [[11]](diffhunk://#diff-bfc0ce5482083cfa4d24600765719eba9f7bae47aecb09310f8af0031d5b6308L23-R23) [[12]](diffhunk://#diff-16e0f57c71af53e62c663368df65e8a734958870ddcd88c494ffbdb783da2d76L27-R27) [[13]](diffhunk://#diff-2d89cba6a55b18ac7cfad33f87046733013cefdffb4a7a5ab005e1c48fa62c32L23-R23) [[14]](diffhunk://#diff-5ce28b1ca49c4f5276b20261a0ebd5291f63f44c5eafebd7c46f2d45918ef0e6L26-R26) [[15]](diffhunk://#diff-156e8ecd48cd00a4daf9d7b5354136e3c16ea3a56faf4ec4fcc6b39fd5743eb1L23-R23) [[16]](diffhunk://#diff-892ffcb0fa8242f617164e6ff52e63feea8c3782e6469dca1fcb3ed8d6580666L23-R23) [[17]](diffhunk://#diff-70bec19fbf234a569e30b78b7d58fea49390eb3d6951e50770f2490b40aab825L27-R27) [[18]](diffhunk://#diff-4438239165404ca65ad8bfa5b7ba732afbc305419f90d2ecc3b9a387f423eee2L24-R24)

Documentation and changelog updates:

* Added a new section for version `1.1.14` in `CHANGELOG.adoc`.
* Updated all dependency version references in `README.adoc` from `1.1.12` to `1.1.14` to match the new release. [[1]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L64-R64) [[2]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L86-R86) [[3]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L128-R128) [[4]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L170-R170) [[5]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L230-R236) [[6]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L249-R249)

These changes prepare the codebase and documentation for the official `1.1.14` release, ensuring users and contributors are referencing the correct, stable version throughout the project.