### PR TITLE
Release 1.2.0 m1

### DIFF
--- a/jnosql-data-tck-runner/pom.xml
+++ b/jnosql-data-tck-runner/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.eclipse.jnosql.mapping</groupId>
 		<artifactId>jnosql-mapping-extensions</artifactId>
-		<version>1.2.0-SNAPSHOT</version>
+		<version>1.2.0-M1</version>
 	</parent>
 
 	<artifactId>jnosql-data-tck-runner</artifactId>

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/pom.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-jakarta-persistence-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M1</version>
     </parent>
 
     <artifactId>jnosql-jakarta-persistence-data-tck-runner</artifactId>

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/pom.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-jakarta-persistence-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M1</version>
     </parent>
 
     <artifactId>jnosql-jakarta-persistence</artifactId>

--- a/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/pom.xml
+++ b/jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-jakarta-persistence-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M1</version>
     </parent>
 
     <artifactId>jnosql-jakarta-persistence-scanner</artifactId>

--- a/jnosql-jakarta-persistence/pom.xml
+++ b/jnosql-jakarta-persistence/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-extensions</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M1</version>
     </parent>
 
     <artifactId>jnosql-jakarta-persistence-parent</artifactId>

--- a/jnosql-lite/mapping-lite-column-test/pom.xml
+++ b/jnosql-lite/mapping-lite-column-test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.lite</groupId>
         <artifactId>jnosql-lite-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M1</version>
     </parent>
 
     <artifactId>mapping-lite-column-test</artifactId>

--- a/jnosql-lite/mapping-lite-core-test/pom.xml
+++ b/jnosql-lite/mapping-lite-core-test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.lite</groupId>
         <artifactId>jnosql-lite-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M1</version>
     </parent>
 
     <artifactId>mapping-lite-core-test</artifactId>

--- a/jnosql-lite/mapping-lite-document-test/pom.xml
+++ b/jnosql-lite/mapping-lite-document-test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.lite</groupId>
         <artifactId>jnosql-lite-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M1</version>
     </parent>
 
     <artifactId>mapping-lite-document-test</artifactId>

--- a/jnosql-lite/mapping-lite-graph-test/pom.xml
+++ b/jnosql-lite/mapping-lite-graph-test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.lite</groupId>
         <artifactId>jnosql-lite-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M1</version>
     </parent>
 
     <artifactId>mapping-lite-graph-test</artifactId>

--- a/jnosql-lite/mapping-lite-key-value-test/pom.xml
+++ b/jnosql-lite/mapping-lite-key-value-test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.lite</groupId>
         <artifactId>jnosql-lite-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M1</version>
     </parent>
 
     <artifactId>mapping-lite-key-value-test</artifactId>

--- a/jnosql-lite/mapping-lite-processor/pom.xml
+++ b/jnosql-lite/mapping-lite-processor/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.lite</groupId>
         <artifactId>jnosql-lite-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M1</version>
     </parent>
 
     <artifactId>mapping-lite-processor</artifactId>

--- a/jnosql-lite/pom.xml
+++ b/jnosql-lite/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-extensions</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M1</version>
     </parent>
 
     <groupId>org.eclipse.jnosql.lite</groupId>

--- a/jnosql-mapping-validation/pom.xml
+++ b/jnosql-mapping-validation/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-extensions</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M1</version>
     </parent>
 
     <artifactId>jnosql-mapping-validation</artifactId>

--- a/jnosql-nosql-tck-runner/pom.xml
+++ b/jnosql-nosql-tck-runner/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-extensions</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M1</version>
     </parent>
 
     <artifactId>jnosql-nosql-tck-runner</artifactId>

--- a/jnosql-static-metamodel/jnosql-metamodel-processor/pom.xml
+++ b/jnosql-static-metamodel/jnosql-metamodel-processor/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.metamodel</groupId>
         <artifactId>jnosql-static-metamodel-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M1</version>
     </parent>
 
     <artifactId>mapping-metamodel-processor</artifactId>

--- a/jnosql-static-metamodel/jnosql-metamodel-sample/pom.xml
+++ b/jnosql-static-metamodel/jnosql-metamodel-sample/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.metamodel</groupId>
         <artifactId>jnosql-static-metamodel-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M1</version>
     </parent>
 
     <artifactId>mapping-lite-sample</artifactId>

--- a/jnosql-static-metamodel/pom.xml
+++ b/jnosql-static-metamodel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-extensions</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M1</version>
     </parent>
 
     <groupId>org.eclipse.jnosql.metamodel</groupId>

--- a/jnosql-tinkerpop-connections/pom.xml
+++ b/jnosql-tinkerpop-connections/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-extensions</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M1</version>
     </parent>
 
     <artifactId>jnosql-tinkerpop-connections</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M1</version>
     </parent>
 
     <artifactId>jnosql-mapping-extensions</artifactId>


### PR DESCRIPTION
This pull request updates the parent project version from `1.2.0-SNAPSHOT` to the milestone release `1.2.0-M1` across all modules in the repository. This change ensures that all submodules consistently depend on the same milestone version, which is likely a step toward preparing for a release or stabilizing the build.

Version update across all modules:

* Updated the parent version from `1.2.0-SNAPSHOT` to `1.2.0-M1` in the following `pom.xml` files:
  - Root project and main modules: `pom.xml`, `jnosql-mapping-validation/pom.xml`, `jnosql-data-tck-runner/pom.xml`, `jnosql-nosql-tck-runner/pom.xml`, `jnosql-tinkerpop-connections/pom.xml`, `jnosql-lite/pom.xml`, `jnosql-static-metamodel/pom.xml` [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L24-R24) [[2]](diffhunk://#diff-2d89cba6a55b18ac7cfad33f87046733013cefdffb4a7a5ab005e1c48fa62c32L23-R23) [[3]](diffhunk://#diff-72be70ac94b01a22f0192470d335d9e18459664ce70f5c9d370cc979b8a76612L27-R27) [[4]](diffhunk://#diff-5ce28b1ca49c4f5276b20261a0ebd5291f63f44c5eafebd7c46f2d45918ef0e6L26-R26) [[5]](diffhunk://#diff-4438239165404ca65ad8bfa5b7ba732afbc305419f90d2ecc3b9a387f423eee2L24-R24) [[6]](diffhunk://#diff-16e0f57c71af53e62c663368df65e8a734958870ddcd88c494ffbdb783da2d76L27-R27) [[7]](diffhunk://#diff-70bec19fbf234a569e30b78b7d58fea49390eb3d6951e50770f2490b40aab825L27-R27)
  - Jakarta Persistence modules: `jnosql-jakarta-persistence/pom.xml`, `jnosql-jakarta-persistence/jnosql-jakarta-persistence-driver/pom.xml`, `jnosql-jakarta-persistence/jnosql-jakarta-persistence-data-tck-runner/pom.xml`, `jnosql-jakarta-persistence/jnosql-jakarta-persistence-scanner/pom.xml` [[1]](diffhunk://#diff-6f76e51fd608138a8daf600ce3d7d8d31a88ff9eb8ab019686684fafbac16769L23-R23) [[2]](diffhunk://#diff-967574e47a06a93754dbf3ca9f98cd6f3cfe419d3c6e1b9c7e07fb11461edf7cL26-R26) [[3]](diffhunk://#diff-a036342e5c2755aa0fd2562a028161db5690d3a7517f37cbfb60b3a74aafdd77L24-R24) [[4]](diffhunk://#diff-879d49e35a76bf05eff31d8a8105370dd2c0f2e79596af4a769b6270711d7eaaL25-R25)
  - Lite modules: `jnosql-lite/mapping-lite-core-test/pom.xml`, `jnosql-lite/mapping-lite-column-test/pom.xml`, `jnosql-lite/mapping-lite-document-test/pom.xml`, `jnosql-lite/mapping-lite-graph-test/pom.xml`, `jnosql-lite/mapping-lite-key-value-test/pom.xml`, `jnosql-lite/mapping-lite-processor/pom.xml` [[1]](diffhunk://#diff-61fd6e3e1e141afc731389613c008e2fb4a68dc2e7fa97b71df98ce5494247c4L23-R23) [[2]](diffhunk://#diff-d953d50d7994a9b3dd4ed263bcd62d804a4f500c217a6e4705710644135a7676L23-R23) [[3]](diffhunk://#diff-5d08708365a4193579002184096342d1e32c6df2073fb4f3d32fa39516a64a13L23-R23) [[4]](diffhunk://#diff-6fb917976a291cbd3864a0b2554846df33ea823366e9f699d2b19243584f8cf1L23-R23) [[5]](diffhunk://#diff-87356e55d6123057951b48f72f8eb581910bff3555ae5c8bf83cd1152b39032eL23-R23) [[6]](diffhunk://#diff-bfc0ce5482083cfa4d24600765719eba9f7bae47aecb09310f8af0031d5b6308L23-R23)
  - Static Metamodel modules: `jnosql-static-metamodel/jnosql-metamodel-processor/pom.xml`, `jnosql-static-metamodel/jnosql-metamodel-sample/pom.xml` [[1]](diffhunk://#diff-156e8ecd48cd00a4daf9d7b5354136e3c16ea3a56faf4ec4fcc6b39fd5743eb1L23-R23) [[2]](diffhunk://#diff-892ffcb0fa8242f617164e6ff52e63feea8c3782e6469dca1fcb3ed8d6580666L23-R23)

No other functional or structural changes are included in this pull request.