### PR TITLE
Fixes Repository Annotation processor and improves the detection and logging 

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 === Fixed
 
 - Fixes the Jakarta Data Query to execute the query with the correct parameters at JNoSQL Lite.
+- Fixes the CDI Lite Repository Annotation processor to generate the correct code for the Repository implementation class.
 
 === Changed
 

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/DatabaseSupport.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/DatabaseSupport.java
@@ -16,6 +16,7 @@ package org.eclipse.jnosql.lite.mapping.repository;
 
 import org.eclipse.jnosql.mapping.DatabaseType;
 
+import javax.annotation.processing.ProcessingEnvironment;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Set;
@@ -36,23 +37,20 @@ enum DatabaseSupport {
         this.databaseType = databaseType;
     }
 
-    boolean isSupported() {
-        try {
-            Class.forName(requiredClassName);
-            return true;
-        } catch (ClassNotFoundException e) {
-            return false;
-        }
+    boolean isSupported(ProcessingEnvironment processingEnv) {
+        return processingEnv.getElementUtils()
+                .getTypeElement(requiredClassName) != null;
     }
 
+
+    static Set<DatabaseType> types(ProcessingEnvironment processingEnv) {
+        return Arrays.stream(values())
+                .filter(databaseSupport -> databaseSupport.isSupported(processingEnv))
+                .map(DatabaseSupport::getDatabaseType)
+                .collect(Collectors.toCollection(() -> EnumSet.noneOf(DatabaseType.class)));
+    }
     DatabaseType getDatabaseType() {
         return databaseType;
     }
 
-    static Set<DatabaseType> types() {
-        return Arrays.stream(values())
-                .filter(DatabaseSupport::isSupported)
-                .map(DatabaseSupport::getDatabaseType)
-                .collect(Collectors.toCollection(() -> EnumSet.noneOf(DatabaseType.class)));
-    }
 }

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryProcessor.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryProcessor.java
@@ -42,9 +42,10 @@ public class RepositoryProcessor extends AbstractProcessor {
     public boolean process(Set<? extends TypeElement> annotations,
                            RoundEnvironment roundEnv) {
 
+        LOGGER.info("Repository processor has started");
         final List<String> repositories = new ArrayList<>();
         try {
-            Set<DatabaseType> types = DatabaseSupport.types();
+            Set<DatabaseType> types = DatabaseSupport.types(processingEnv);
             for (TypeElement annotation : annotations) {
                 for (DatabaseType type : types) {
                     roundEnv.getElementsAnnotatedWith(annotation)

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryProcessor.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryProcessor.java
@@ -59,6 +59,7 @@ public class RepositoryProcessor extends AbstractProcessor {
             error(exception);
         }
         LOGGER.info("Repository processor has finished with those classes generated: " + repositories.size());
+        LOGGER.fine("Repository processor has finished with those classes generated: " + repositories);
         return false;
     }
 

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryProcessor.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryProcessor.java
@@ -58,9 +58,7 @@ public class RepositoryProcessor extends AbstractProcessor {
         } catch (Exception exception) {
             error(exception);
         }
-        if (!repositories.isEmpty()) {
-            LOGGER.info("Repository processor has finished with those classes generated: " + repositories.size());
-        }
+        LOGGER.info("Repository processor has finished with those classes generated: " + repositories.size());
         return false;
     }
 

--- a/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryProcessor.java
+++ b/jnosql-lite/mapping-lite-processor/src/main/java/org/eclipse/jnosql/lite/mapping/repository/RepositoryProcessor.java
@@ -46,6 +46,7 @@ public class RepositoryProcessor extends AbstractProcessor {
         final List<String> repositories = new ArrayList<>();
         try {
             Set<DatabaseType> types = DatabaseSupport.types(processingEnv);
+            LOGGER.info("Repository processor has found the following databases: " + types);
             for (TypeElement annotation : annotations) {
                 for (DatabaseType type : types) {
                     roundEnv.getElementsAnnotatedWith(annotation)


### PR DESCRIPTION
This pull request addresses issues with the CDI Lite Repository Annotation processor and improves the detection and logging of supported database types during code generation. The most important changes are:

**Bug Fixes:**

* Fixed the CDI Lite Repository Annotation processor so it generates the correct code for the Repository implementation class.

**Processor Logic Improvements:**

* Changed the way supported database types are detected: `DatabaseSupport` now uses the `ProcessingEnvironment` to check for available types, making detection more reliable during annotation processing.
* Updated `RepositoryProcessor` to pass the `processingEnv` to `DatabaseSupport.types`, ensuring accurate detection of available databases.

**Logging Enhancements:**

* Improved logging in `RepositoryProcessor` to show when processing starts, which databases are found, and detailed information about generated repository classes. [[1]](diffhunk://#diff-f5785ef9323320d206eb094fac3bde6e43bf61c6330f49a7ef0cb96279b347afR45-R49) [[2]](diffhunk://#diff-f5785ef9323320d206eb094fac3bde6e43bf61c6330f49a7ef0cb96279b347afL59-R62)

**Dependency Updates:**

* Added import for `ProcessingEnvironment` in `DatabaseSupport.java` to support the new detection logic.


https://github.com/quarkiverse/quarkus-jnosql/issues/408#issuecomment-4865312099